### PR TITLE
fix net target build issue

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -82,12 +82,13 @@
 			</classpath>
 		</javac>
 	</target>
-	<target name="build-net" depends="build-core">
+	<target name="build-net" depends="build-core, build-application">
 		<echo message="Building net package" />
 		<javac debug="true" debuglevel="${debuglevel}" destdir="bin/net" source="${source}" target="${target}" includeantruntime="false">
 			<src path="net" />
 			<classpath>
 				<path location="bin/core" />
+				<path location="bin/application" />
 			</classpath>
 		</javac>
 	</target>


### PR DESCRIPTION
fixes following build issue:

```
↪ ant
Buildfile: /home/matej/prace/sport_tracking/3rd_party/aibu_anntation/coffeeshop/build.xml

ivy:

init:

build-core:
     [echo] Building core package

build-application:
     [echo] Building application package

build-gui:
     [echo] Building gui package

build-animation:
     [echo] Building animation package

build-figure:
     [echo] Building figure package

build-net:
     [echo] Building net package
    [javac] Compiling 21 source files to /home/matej/prace/sport_tracking/3rd_party/aibu_anntation/coffeeshop/bin/net
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 1.5
    [javac] warning: [options] source value 1.5 is obsolete and will be removed in a future release
    [javac] warning: [options] target value 1.5 is obsolete and will be removed in a future release
    [javac] warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
    [javac] /home/matej/prace/sport_tracking/3rd_party/aibu_anntation/coffeeshop/net/org/coffeeshop/net/http/server/HttpServerThread.java:6: error: package org.coffeeshop.application does not exist
    [javac] import org.coffeeshop.application.Application;
    [javac]                                  ^
    [javac] /home/matej/prace/sport_tracking/3rd_party/aibu_anntation/coffeeshop/net/org/coffeeshop/net/http/server/HttpServerThread.java:155: error: cannot find symbol
    [javac] 							Application.getApplicationLogger().report(e);
    [javac] 							^
    [javac]   symbol:   variable Application
    [javac]   location: class HttpServerThread
    [javac] 2 errors
    [javac] 4 warnings

BUILD FAILED
/home/matej/prace/sport_tracking/3rd_party/aibu_anntation/coffeeshop/build.xml:87: Compile failed; see the compiler error output for details.

Total time: 3 seconds

```

```
↪ javac -version
javac 1.8.0_45
```