### PR TITLE
fix build fail when .ant is not present

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -9,7 +9,6 @@
 	</tstamp>
     <target name="ivy">
         <path id="ivy.lib.path">
-            <fileset dir="${user.home}/.ant/" includes="*.jar"/>
             <fileset dir="/usr/share/java/" includes="*.jar"/>
         </path>
         <taskdef resource="org/apache/ivy/ant/antlib.xml"


### PR DESCRIPTION
This path is not needed (on my setup) and causes build fail when ~/.ant is not present.